### PR TITLE
Add support for puppet 3.5.0

### DIFF
--- a/lib/puppet/parser/functions/template_body.rb
+++ b/lib/puppet/parser/functions/template_body.rb
@@ -1,6 +1,6 @@
 Puppet::Parser::Functions::newfunction(:template_body, :type => :rvalue) do |args|
   args.collect do |file|
-    unless filename = Puppet::Parser::Files.find_template(file, self.compiler.environment.to_s)
+    unless filename = Puppet::Parser::Files.find_template(file, self.compiler.environment)
       raise Puppet::ParseError, "Could not find template '#{filename}'"
     end
     File.read(filename)


### PR DESCRIPTION
In puppet 3.5.0 'find_template' can no longer deal with strings for
parameter environment.
