### PR TITLE
reshape the travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
 rvm:
   - 1.8.7
   - 1.9.3
-  - ruby-head
 env:
   - PUPPET_GEM_VERSION="~> 2.6.0"
   - PUPPET_GEM_VERSION="~> 2.7.0"
@@ -12,17 +11,13 @@ env:
   - PUPPET_GEM_VERSION="~> 3.1.0"
   - PUPPET_GEM_VERSION="~> 3.2.0"
   - PUPPET_GEM_VERSION="~> 3.3.0"
+  - PUPPET_GEM_VERSION="~> 3.4.0"
+  - PUPPET_GEM_VERSION="~> 3.5.0"
 matrix:
-  allow_failures:
-    - rvm: ruby-head
   exclude:
     - rvm: 1.9.3
       env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: ruby-head
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
     - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.6.0"
-    - rvm: ruby-head
       env: PUPPET_GEM_VERSION="~> 2.6.0"
 notifications:
   email: false


### PR DESCRIPTION
Drop testing ruby-head, but bring in more puppet versions (3.4,
3.5)
