### PR TITLE
implement ensure parameter for datacat defined type

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Types and Definitions
 Wraps the `datacat_collector` and `file` types to cover the most common
 use-case, collecting data for and templating an entire file.
 
+The `ensure` parameter defaults to `file` (an alias for `present`). `ensure`
+can be set to `absent`. In that case `datacat` will make sure the file *does
+not exist* and will not collect anything with `datacat_collector`.
+
 ## Type: `datacat_collector`
 
 The `datacat_collector` type deeply merges a data hash from

--- a/spec/defines/datacat_spec.rb
+++ b/spec/defines/datacat_spec.rb
@@ -16,4 +16,12 @@ describe "datacat" do
     it { should contain_datacat_collector('test').with_template('inline') }
     it { should contain_datacat_collector('test').with_template_body(/Baah/) }
   end
+
+  context "specifying ensure absent" do
+    let(:title) { 'no-file' }
+    let(:params) { { :ensure => "absent" } }
+    it { should_not contain_datacat_collector('no-file') }
+    it { should contain_file('no-file') }
+    it { should contain_file('no-file').with_ensure('absent') }
+  end
 end


### PR DESCRIPTION
since `datacat` manages a file, it can be useful, for symmetry to pass an
ensure parameter down to that file.

Since it can be useful to manage the _existence_ of such such a file in
a module, the `datacat` type has an `ensure` parameter that defaults to
`file` (an alias for `present`). `ensure` can also be set to `absent`.
In that case `datacat` will make sure the file _doesn't exist_ and will
not collect anything with `datacat_collector`.
