### PR TITLE
Fixed wrong case statements

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,13 +74,13 @@ define datacat(
     }
 
     $template_real = $template ? {
-      default => $template,
       undef   => 'inline',
+      default => $template,
     }
 
     $template_body_real = $template_body ? {
-      default => $template_body,
       undef   => template_body($template_real),
+      default => $template_body,
     }
 
     datacat_collector { $title:


### PR DESCRIPTION
Puppet doc says:

> ```
> Cases are compared in the order that they are written in the manifest; thus, the default case (if any) must be at the end of the list.
> ```

This also makes datacat work when using future parser
