### PR TITLE
add a ensure on file resource in order to be context-independent

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,7 @@ define datacat(
     }
   } else {
     file { $title:
+      ensure                  => $ensure,
       path                    => $path,
       backup                  => $backup,
       checksum                => $checksum,

--- a/spec/classes/ensure_file_spec.rb
+++ b/spec/classes/ensure_file_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'ensure_file' do
+  it { should contain_file('/tmp/ensure_file').with_ensure('file') }
+end

--- a/spec/fixtures/modules/ensure_file/manifests/init.pp
+++ b/spec/fixtures/modules/ensure_file/manifests/init.pp
@@ -1,0 +1,23 @@
+class ensure_file {
+
+  File { 
+    ensure => directory,
+  }
+  
+  #Etc...
+
+  datacat { '/tmp/ensure_file':
+    template => 'ensure_file/sheeps.erb',
+  }
+
+  datacat_fragment { 'data foo => 1':
+    target => '/tmp/ensure_file',
+    data   => { foo => 1 },
+  }
+
+  datacat_fragment { 'data bar => 2':
+    target => '/tmp/ensure_file',
+    data   => { bar => 2 },
+  }
+}
+

--- a/spec/fixtures/modules/ensure_file/templates/sheeps.erb
+++ b/spec/fixtures/modules/ensure_file/templates/sheeps.erb
@@ -1,0 +1,3 @@
+# This is a super simple demonstration - baah!
+
+<%= @data.to_yaml %>


### PR DESCRIPTION
add an explicit 'ensure' on file resource because the profile may set a default ensure for File type ( like ensure => directory)
