### PR TITLE
Move rspec-system to the developer collection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 group :development, :test do
   gem 'rake'
   gem 'puppetlabs_spec_helper', :require => false
-  gem 'rspec-system-puppet', '~>2.0'
   gem 'puppet-lint'
 end
 
@@ -13,6 +12,7 @@ group :development do
   gem 'pry-debugger'
   gem 'rb-readline'
   gem 'awesome_print'
+  gem 'rspec-system-puppet', '~>2.0'
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,6 @@ Bundler.require :default
 
 require 'rspec/core/rake_task'
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'rspec-system/rake_task'
 
 task :default do
   sh %{rake -T}


### PR DESCRIPTION
rspec-system-puppet now depends on new version of beaker which is breaking
travisci builds.

Here we move rspec-system-puppet to the development section, and disable it
from working by default.

This leaves us with non-functional rspec-system tests, that will need to be
ported to use beaker-rspec instead -
https://github.com/richardc/puppet-datacat/issues/30