### PR TITLE
select debugger gem dependent on ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ end
 
 group :development do
   gem 'pry'
-  gem 'pry-debugger'
+  gem 'pry-debugger', :platform => :mri_19
+  gem 'pry-byebug',   :platform => [:mri_20, :mri_21 ,:mri_22, :mri_23]
   gem 'rb-readline'
   gem 'awesome_print'
   gem 'rspec-system-puppet', '~>2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,11 @@ end
 
 group :development do
   gem 'pry'
-  gem 'pry-debugger', :platform => :mri_19
-  gem 'pry-byebug',   :platform => [:mri_20, :mri_21 ,:mri_22, :mri_23]
+  if RUBY_VERSION <= '1.9.3'
+    gem 'pry-debugger'
+  else
+    gem 'pry-byebug'
+  end
   gem 'rb-readline'
   gem 'awesome_print'
   gem 'rspec-system-puppet', '~>2.0'


### PR DESCRIPTION
pry-debugger depends on debugger, which cannot be installed on
ruby>=2.0. An extensive, lengthy and sometimes unnerving discussion can
be found on https://github.com/cldwalker/debugger/issues/125

On May 16, 2014, cldwalker suggested moving to byebug for
rubies>=2. This is reflected in the change to Gemfile.

	modified:   Gemfile

Thanks for your work on puppet-datacat! Cheers!