### PR TITLE
Pin gems to support the older versions of ruby in the matrix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,12 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'rake'
+  if RUBY_VERSION =~ /^1.8\./
+    # Rake 11.0 removes support for ruby 1.8; pin to previous version.
+    gem 'rake', '~> 10.4.2'
+  else
+    gem 'rake'
+  end
   gem 'puppetlabs_spec_helper', :require => false
   gem 'puppet-lint'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,12 @@ group :development do
   gem 'rspec-system-puppet', '~>2.0'
 end
 
+# json/json_pure are transitive dependences of puppet.
+# They dropped support for ruby 1.8 and 1.9 in their 2.0 releases
+# https://github.com/flori/json/blob/master/CHANGES.md#2015-09-11-200
+gem 'json', '~> 1.8.0', :platform => [:ruby_18, :ruby_19]
+gem 'json_pure', '~> 1.8.0', :platform => [:ruby_18, :ruby_19]
+
 if puppetversion = ENV['PUPPET_GEM_VERSION']
   gem 'puppet', puppetversion, :require => false
 else


### PR DESCRIPTION
json_pure (and json) are common transitive dependencies.  In 2.0 they
chose to drop support for earlier ruby releases.

Also over in the rake project, they chose to drop support for 1.8 in 11.0

These changes should be enough to address the bits moving and restore stability to the travis matrix.