### PR TITLE
Modification for rspec-puppet testing

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,10 +32,13 @@ define datacat(
   $selrole                 = undef,
   $seltype                 = undef,
   $seluser                 = undef,
-  $show_diff               = 'UNSET'
+  $show_diff               = 'UNSET',
 ) {
   if $show_diff != 'UNSET' {
-    if versioncmp($settings::puppetversion, '3.2.0') >= 0 {
+    # Set this hieradata parameter when testing (rspec-puppet), otherwise rely on the default value
+    $puppetversion = lookup('datacat::puppetversion', { 'default_value' => $::settings::puppetversion })
+
+    if versioncmp($puppetversion, '3.2.0') >= 0 {
       File { show_diff => $show_diff }
     } else {
       warning('show_diff not supported in puppet prior to 3.2, ignoring')


### PR DESCRIPTION
Rspec-puppet cannot access puppet master variables[1]. The only advice I've discovered is to make these values parameters with defaults set as the `$::settings` value (or in this case as a lookup with a default value).

[1] https://puppet.com/docs/puppet/5.4/lang_facts_and_builtin_vars.html#puppet-master-variables